### PR TITLE
Convert duration to Joda Duration

### DIFF
--- a/src/main/scala/com/thenewmotion/ochp/api/CDR.scala
+++ b/src/main/scala/com/thenewmotion/ochp/api/CDR.scala
@@ -11,7 +11,7 @@ case class CDR(
   status: CdrStatus.Value,
   startDateTime: DateTime,
   endDateTime: DateTime,
-  duration: Option[String] = None,
+  duration: Option[Duration] = None,
   houseNumber: Option[String] = None,
   address: Option[String] = None,
   zipCode: Option[String] = None,

--- a/src/main/scala/com/thenewmotion/ochp/client/OchpClient.scala
+++ b/src/main/scala/com/thenewmotion/ochp/client/OchpClient.scala
@@ -2,6 +2,7 @@ package com.thenewmotion.ochp
 package client
 
 import converters.Converters._
+import converters.CDRConverter
 import converters.DateTimeConverters._
 import java.util.{HashMap => JMap}
 import javax.xml.namespace.QName
@@ -60,7 +61,7 @@ class OchpClient(cxfClient: OCHP13) {
   def getCdrs() = {
     val resp: GetCDRsResponse = cxfClient.getCDRs(
       new GetCDRsRequest)
-    resp.getCdrInfoArray.asScala.toList.map(implicitly[CDR](_))
+    resp.getCdrInfoArray.asScala.toList.flatMap(CDRConverter.fromOchp)
   }
 
   def addCdrs(cdrs: Seq[CDR]) = {
@@ -68,7 +69,7 @@ class OchpClient(cxfClient: OCHP13) {
     req.getCdrInfoArray.addAll(cdrs.map(implicitly[CDRInfo](_)).asJava)
     val resp = cxfClient.addCDRs(req)
     Result[CDR](resp.getResult.getResultCode.getResultCode, resp.getResult.getResultDescription,
-      resp.getImplausibleCdrsArray.asScala.toList.map(implicitly[CDR](_)))
+      resp.getImplausibleCdrsArray.asScala.toList.flatMap(CDRConverter.fromOchp))
   }
 
   def confirmCdrs(approvedCdrs: Seq[CDR], declinedCdrs: Seq[CDR]) = {

--- a/src/main/scala/com/thenewmotion/ochp/converters/CDRConverter.scala
+++ b/src/main/scala/com/thenewmotion/ochp/converters/CDRConverter.scala
@@ -1,0 +1,66 @@
+package com.thenewmotion.ochp
+package converters
+
+import api._
+import eu.ochp._1.CDRInfo
+import DateTimeConverters._
+
+import org.slf4j.LoggerFactory
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success}
+
+
+object CDRConverter extends Common {
+  private val logger = LoggerFactory.getLogger(CDRConverter.getClass)
+
+  def fromOchp(cdrinfo: CDRInfo): Option[CDR] = {
+    val cdr = for {
+      duration <- safeReadWith(cdrinfo.getDuration)(DurationConverter.fromOchp(_))
+    } yield CDR (
+      cdrId = cdrinfo.getCdrId,
+      evseId = cdrinfo.getEvseId,
+      emtId = EmtId(
+        tokenId = cdrinfo.getEmtId.getInstance,
+        tokenType = TokenType.withName(cdrinfo.getEmtId.getTokenType),
+        tokenSubType = Option(cdrinfo.getEmtId.getTokenSubType) map {TokenSubType.withName}
+      ),
+      contractId = cdrinfo.getContractId,
+      liveAuthId = toNonEmptyOption(cdrinfo.getLiveAuthId),
+      status = CdrStatus.withName(cdrinfo.getStatus.getCdrStatusType),
+      startDateTime = WithOffset.fromOchp(cdrinfo.getStartDateTime),
+      endDateTime = WithOffset.fromOchp(cdrinfo.getEndDateTime),
+      duration = duration,
+      houseNumber = toNonEmptyOption(cdrinfo.getHouseNumber),
+      address = toNonEmptyOption(cdrinfo.getAddress),
+      zipCode = toNonEmptyOption(cdrinfo.getZipCode),
+      city = toNonEmptyOption(cdrinfo.getCity),
+      country = cdrinfo.getCountry,
+      chargePointType = cdrinfo.getChargePointType,
+      connectorType = Connector(
+        connectorStandard = ConnectorStandard.withName(
+          cdrinfo.getConnectorType.getConnectorStandard.getConnectorStandard),
+        connectorFormat = ConnectorFormat.withName(
+          cdrinfo.getConnectorType.getConnectorFormat.getConnectorFormat)),
+      maxSocketPower = cdrinfo.getMaxSocketPower,
+      productType = toNonEmptyOption(cdrinfo.getProductType),
+      meterId = toNonEmptyOption(cdrinfo.getMeterId),
+      chargingPeriods = cdrinfo.getChargingPeriods.asScala.toList.map( cdrPeriod=> {
+        val cost = cdrPeriod.getPeriodCost
+        CdrPeriod(
+          startDateTime = WithOffset.fromOchp(cdrPeriod.getStartDateTime),
+          endDateTime = WithOffset.fromOchp(cdrPeriod.getEndDateTime),
+          billingItem = BillingItem.withName(cdrPeriod.getBillingItem.getBillingItemType),
+          billingValue = cdrPeriod.getBillingValue,
+          currency = cdrPeriod.getCurrency,
+          itemPrice = cdrPeriod.getItemPrice,
+          periodCost = Option(cost).map(_.toFloat)
+        )
+      })
+    )
+
+    cdr match {
+      case Success(x) => Some(x)
+      case Failure(e) => logger.error("CDR conversion failure", e); None
+    }
+  }
+}

--- a/src/main/scala/com/thenewmotion/ochp/converters/Converters.scala
+++ b/src/main/scala/com/thenewmotion/ochp/converters/Converters.scala
@@ -13,17 +13,9 @@ import scala.util.{Try, Success, Failure}
 import scala.language.{implicitConversions, postfixOps}
 import scala.collection.JavaConverters._
 
+trait Common {
 
-/**
- *
- * Convert between cxf-generated java classes and nice scala case classes
- *
- */
-object Converters {
-
-  private val logger = LoggerFactory.getLogger(Converters.getClass)
-
-  private def safeRead[T, U](possiblyNull: T)(convert: T => U): Try[Option[U]] = {
+  def safeRead[T, U](possiblyNull: T)(convert: T => U): Try[Option[U]] = {
     Option(possiblyNull) match {
       case None => Success(None)
       case Some(value) =>
@@ -31,15 +23,27 @@ object Converters {
       }
   }
 
-  private def safeReadWith[T, U](possiblyNull: T)(convert: T => Try[U]): Try[Option[U]] =
+  def safeReadWith[T, U](possiblyNull: T)(convert: T => Try[U]): Try[Option[U]] =
     Option(possiblyNull) match {
       case None => Success(None)
       case Some(value) =>
         convert(value).map(Some(_))
       }
 
-  private def toNonEmptyOption(value: String): Option[String] =
+  def toNonEmptyOption(value: String): Option[String] =
     Option(value).filter(_.nonEmpty)
+
+}
+
+
+/**
+ *
+ * Convert between cxf-generated java classes and nice scala case classes
+ *
+ */
+object Converters extends Common {
+
+  private val logger = LoggerFactory.getLogger(Converters.getClass)
 
   implicit def roamingAuthorisationInfoToToken(rai: RoamingAuthorisationInfo): ChargeToken = {
     ChargeToken(
@@ -139,49 +143,6 @@ object Converters {
 
     safeReadWith(value)(regularOpeningsAreDefined(_).map(fromJava))
   }
-
-  implicit def cdrInfoToCdr(cdrinfo: CDRInfo): CDR =
-    CDR(
-      cdrId = cdrinfo.getCdrId,
-      evseId = cdrinfo.getEvseId,
-      emtId = EmtId(
-        tokenId = cdrinfo.getEmtId.getInstance,
-        tokenType = TokenType.withName(cdrinfo.getEmtId.getTokenType),
-        tokenSubType = Option(cdrinfo.getEmtId.getTokenSubType) map {TokenSubType.withName}
-      ),
-      contractId = cdrinfo.getContractId,
-      liveAuthId = toNonEmptyOption(cdrinfo.getLiveAuthId),
-      status = CdrStatus.withName(cdrinfo.getStatus.getCdrStatusType),
-      startDateTime = WithOffset.fromOchp(cdrinfo.getStartDateTime),
-      endDateTime = WithOffset.fromOchp(cdrinfo.getEndDateTime),
-      duration = toNonEmptyOption(cdrinfo.getDuration),
-      houseNumber = toNonEmptyOption(cdrinfo.getHouseNumber),
-      address = toNonEmptyOption(cdrinfo.getAddress),
-      zipCode = toNonEmptyOption(cdrinfo.getZipCode),
-      city = toNonEmptyOption(cdrinfo.getCity),
-      country = cdrinfo.getCountry,
-      chargePointType = cdrinfo.getChargePointType,
-      connectorType = Connector(
-        connectorStandard = ConnectorStandard.withName(
-          cdrinfo.getConnectorType.getConnectorStandard.getConnectorStandard),
-        connectorFormat = ConnectorFormat.withName(
-          cdrinfo.getConnectorType.getConnectorFormat.getConnectorFormat)),
-      maxSocketPower = cdrinfo.getMaxSocketPower,
-      productType = toNonEmptyOption(cdrinfo.getProductType),
-      meterId = toNonEmptyOption(cdrinfo.getMeterId),
-      chargingPeriods = cdrinfo.getChargingPeriods.asScala.toList.map( cdrPeriod=> {
-        val cost = cdrPeriod.getPeriodCost
-        CdrPeriod(
-          startDateTime = WithOffset.fromOchp(cdrPeriod.getStartDateTime),
-          endDateTime = WithOffset.fromOchp(cdrPeriod.getEndDateTime),
-          billingItem = BillingItem.withName(cdrPeriod.getBillingItem.getBillingItemType),
-          billingValue = cdrPeriod.getBillingValue,
-          currency = cdrPeriod.getCurrency,
-          itemPrice = cdrPeriod.getItemPrice,
-          periodCost = Option(cost).map(_.toFloat)
-        )
-      })
-    )
 
   implicit def cdrToCdrInfo(cdr: CDR): CDRInfo = {
     import cdr._

--- a/src/main/scala/com/thenewmotion/ochp/converters/Converters.scala
+++ b/src/main/scala/com/thenewmotion/ochp/converters/Converters.scala
@@ -5,6 +5,7 @@ import api._
 import ChargePointStatus.ChargePointStatus
 import com.thenewmotion.time.Imports._
 import DateTimeConverters._
+import DurationConverter._
 import GeoPointConverters._
 import eu.ochp._1.{ConnectorType => GenConnectorType, EvseImageUrlType => GenEvseImageUrlType, EmtId => GenEmtId, CdrStatusType => GenCdrStatusType, ConnectorFormat => GenConnectorFormat, ConnectorStandard => GenConnectorStandard, CdrPeriodType => GenCdrPeriodType, BillingItemType => GenBillingItemType, EvseStatusType => GetEvseStatusType, _}
 import org.slf4j.LoggerFactory
@@ -202,7 +203,7 @@ object Converters {
     cdr.zipCode match {case Some(s) if !s.isEmpty => cdrInfo.setZipCode(s)}
     cdr.city match {case Some(s) if !s.isEmpty => cdrInfo.setCity(s)}
     cdrInfo.setCountry(cdr.country)
-    cdr.duration  match {case Some(s) if !s.isEmpty => cdrInfo.setDuration(s)}
+    cdr.duration.map(d => cdrInfo.setDuration(toOchp(d)))
     val eid = new GenEmtId()
     eid.setInstance(cdr.emtId.tokenId)
     eid.setTokenType(cdr.emtId.tokenType.toString)

--- a/src/main/scala/com/thenewmotion/ochp/converters/DurationConverter.scala
+++ b/src/main/scala/com/thenewmotion/ochp/converters/DurationConverter.scala
@@ -1,0 +1,38 @@
+package com.thenewmotion.ochp
+package converters
+
+import com.thenewmotion.time.Imports._
+import org.joda.time.PeriodType
+
+import scala.util.{Failure, Try}
+
+
+trait DurationConverter {
+  private val OchpFormat = """(\d{3}):(\d{2}):(\d{2})""".r
+
+  def toOchp(d: Duration): String = {
+    val p = d.toPeriod(PeriodType.time())
+
+    val hours = "%03d".format(p.getHours)
+    val minutes = "%02d".format(p.getMinutes)
+    val seconds = "%02d".format(p.getSeconds)
+
+    s"$hours:$minutes:$seconds"
+  }
+
+  def fromOchp(value: String): Try[Duration] = {
+    value match {
+      case OchpFormat(hours, minutes, seconds) =>
+        for {
+          hours <- Try(Duration.standardHours(hours.toLong))
+          minutes <- Try(Duration.standardMinutes(minutes.toLong))
+          seconds <- Try(Duration.standardSeconds(seconds.toLong))
+        } yield seconds.plus(minutes).plus(hours)
+      case _ => Failure(
+        new IllegalArgumentException(
+          s"Cannot parse $value as duration. Expected format is 000:00:00 (hours:minutes:seconds)"))
+    }
+  }
+}
+
+object DurationConverter extends DurationConverter

--- a/src/test/scala/com/thenewmotion/ochp/converters/CDRSpec.scala
+++ b/src/test/scala/com/thenewmotion/ochp/converters/CDRSpec.scala
@@ -2,6 +2,7 @@ package com.thenewmotion.ochp
 package converters
 
 import Converters._
+import CDRConverter._
 import api._
 import com.thenewmotion.time.Imports._
 
@@ -42,6 +43,6 @@ class CDRSpec extends Spec {
           itemPrice = 6,
           periodCost = Some(5))))
 
-    cdrInfoToCdr(cdrToCdrInfo(cdr)) mustEqual cdr
+    fromOchp(cdrToCdrInfo(cdr)) must beSome(cdr)
   }
 }

--- a/src/test/scala/com/thenewmotion/ochp/converters/CDRSpec.scala
+++ b/src/test/scala/com/thenewmotion/ochp/converters/CDRSpec.scala
@@ -3,6 +3,7 @@ package converters
 
 import Converters._
 import api._
+import com.thenewmotion.time.Imports._
 
 class CDRSpec extends Spec {
   "converting a CDR into CDRInfo and back returns the original value" >> {
@@ -18,7 +19,7 @@ class CDRSpec extends Spec {
       status = CdrStatus.withName("new"),
       startDateTime = DateTimeNoMillis("2014-08-08T10:10:10+01:00"),
       endDateTime = DateTimeNoMillis("2014-08-08T18:10:10+01:00"),
-      duration = Some("200"),
+      duration = Some(Duration.standardMinutes(10)),
       houseNumber = Some("585"),
       address = Some("Keizersgracht"),
       zipCode = Some("1017 DR"),

--- a/src/test/scala/com/thenewmotion/ochp/converters/DurationSpec.scala
+++ b/src/test/scala/com/thenewmotion/ochp/converters/DurationSpec.scala
@@ -1,0 +1,13 @@
+package com.thenewmotion.ochp
+package converters
+
+import converters.DurationConverter._
+
+
+class DurationSpec extends Spec {
+  "converting from Ochp and back yields the original value" >> {
+    val duration = "123:45:59"
+
+    fromOchp(duration).map(toOchp) must beSuccessfulTry(duration)
+  }
+}


### PR DESCRIPTION
Working with a string duration (with a non-ISO format) is not very convenient for clients of this library, because they are then forced to define their own de/serializers
